### PR TITLE
Add encryption

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ SERVER_SOURCES=$(wildcard src/kazlib/*.c src/server/*.c src/*.c) ${PROTO_C_COMPI
 SERVER_OBJECTS=$(patsubst %.c,%.o,${SERVER_SOURCES})
 FS_SOURCES=$(wildcard src/kazlib/*.c src/fs/*.c src/*.c) ${PROTO_C_COMPILED}
 FS_OBJECTS=$(patsubst %.c,%.o,${FS_SOURCES})
-
+TOOLS_SOURCES=$(wildcard src/tools/*.c)
+TOOLS_OBJECTS=$(patsubst %.c,%.o,${TOOLS_SOURCES})
 
 # do not strip debuging information in release builds
 release: CFLAGS+=-DNDEBUG -O2 -g
@@ -40,7 +41,7 @@ release: all
 dev: CFLAGS+=-DDEBUG -O0 -g
 dev: all
 
-all: ${BINDIR}/rhizosrv ${BINDIR}/rhizofs
+all: ${BINDIR}/rhizosrv ${BINDIR}/rhizofs ${BINDIR}/rhizo-keygen
 
 ${BINDIR}:
 	@[ -d ${BINDIR} ] || mkdir ${BINDIR}
@@ -50,6 +51,9 @@ ${BINDIR}/rhizosrv: ${SERVER_OBJECTS} ${BINDIR}
 
 ${BINDIR}/rhizofs: ${FS_OBJECTS} ${BINDIR}
 	$(CC) -o ${BINDIR}/rhizofs ${FS_OBJECTS} $(CFLAGS) $(LIBS) $(FUSE_LIBS)
+
+${BINDIR}/rhizo-keygen: ${TOOLS_OBJECTS} ${BINDIR}
+	$(CC) -o ${BINDIR}/rhizo-keygen ${TOOLS_OBJECTS} $(CFLAGS) -lzmq
 
 ${SERVER_SOURCES} ${FS_SOURCES}: ${PROTO_H_COMPILED}
 
@@ -63,7 +67,7 @@ ${SERVER_SOURCES} ${FS_SOURCES}: ${PROTO_H_COMPILED}
 	$(PROTOCC) --c_out=./ $<
 
 clean:
-	rm -f ${SERVER_OBJECTS} ${FS_OBJECTS} ${PROTO_C_COMPILED} ${PROTO_H_COMPILED}
+	rm -f ${SERVER_OBJECTS} ${FS_OBJECTS} ${TOOLS_OBJECTS} ${PROTO_C_COMPILED} ${PROTO_H_COMPILED}
 	rm -rf ${BINDIR}
 
 valgrind-srv: dev ${BINDIR}/rhizosrv
@@ -75,3 +79,5 @@ deb:
 install: release
 	install ${BINDIR}/rhizosrv $(PREFIX)/bin/
 	install ${BINDIR}/rhizofs $(PREFIX)/bin/
+	install ${BINDIR}/rhizo-keygen $(PREFIX)/bin/
+

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,15 @@ CFLAGS= -Wall \
 	-Isrc \
 	-D_XOPEN_SOURCE=600 \
 	-D_DEFAULT_SOURCE \
-	-I. $(shell pkg-config fuse --cflags)
+	-I. $(shell pkg-config fuse --cflags) \
+	-I. $(shell pkg-config libprotobuf-c --cflags) \
+	-I. $(shell pkg-config libzmq --cflags)
 
 # clang emits a warning if the -std flag is passed to it when linking
 # objects
 CFLAGS_EXTRA = -std=c99
 
-LIBS=-lzmq -lprotobuf-c -lpthread
+LIBS=$(shell pkg-config libzmq --libs) $(shell pkg-config libprotobuf-c --libs) -lpthread
 FUSE_LIBS=$(shell pkg-config fuse --libs)
 
 # tools
@@ -53,7 +55,7 @@ ${BINDIR}/rhizofs: ${FS_OBJECTS} ${BINDIR}
 	$(CC) -o ${BINDIR}/rhizofs ${FS_OBJECTS} $(CFLAGS) $(LIBS) $(FUSE_LIBS)
 
 ${BINDIR}/rhizo-keygen: ${TOOLS_OBJECTS} ${BINDIR}
-	$(CC) -o ${BINDIR}/rhizo-keygen ${TOOLS_OBJECTS} $(CFLAGS) -lzmq
+	$(CC) -o ${BINDIR}/rhizo-keygen ${TOOLS_OBJECTS} $(CFLAGS) $(shell pkg-config libzmq --libs)
 
 ${SERVER_SOURCES} ${FS_SOURCES}: ${PROTO_H_COMPILED}
 

--- a/src/fs/rhizofs.c
+++ b/src/fs/rhizofs.c
@@ -43,6 +43,11 @@ typedef struct RhizoSettings {
     char *server_public_key;
     char *server_public_key_file;
 
+    char *client_public_key_file;
+
+    char *client_public_key;
+    char *client_secret_key;
+
     /** timeout (in seconds) after which the filesystem will stop waiting
      *  * for a response from the server
      *  * for being able to send the request to the server
@@ -76,6 +81,7 @@ static struct fuse_opt rhizo_opts[] = {
     OPTION("--pubkeyfile=%s", server_public_key_file),
     OPTION("-k=%s",           server_public_key),
     OPTION("--pubkey=%s",     server_public_key),
+    OPTION("--clientpubkeyfile=%s", client_public_key_file),
     FUSE_OPT_END
 };
 
@@ -113,6 +119,8 @@ Rhizofs_init(struct fuse_conn_info * UNUSED_PARAMETER(conn))
 
     if (settings.server_public_key != NULL)
         SocketPool_set_server_public_key(&socketpool, settings.server_public_key);
+    if (settings.client_public_key != NULL && settings.client_secret_key != NULL)
+        SocketPool_set_client_keypair(&socketpool, settings.client_public_key, settings.client_secret_key);
 
     check((AttrCache_init(&attrcache, ATTRCACHE_MAXSIZE, ATTRCACHE_DEFAULT_MAXAGE_SEC) == true),
             "could not initialize the attrcache");
@@ -1119,7 +1127,8 @@ Rhizofs_check_connection(RhizoPriv * priv)
 
     fprintf(stdout, "Trying to connect to server at %s\n", settings.host_socket);
 
-    socket = create_socket(priv->context, ZMQ_REQ, settings.server_public_key);
+    socket = create_socket(priv->context, ZMQ_REQ, settings.server_public_key,
+                           settings.client_public_key, settings.client_secret_key);
     check((socket != NULL), "Could not create 0mq socket");
 
     if (zmq_connect(socket, settings.host_socket) != 0) {
@@ -1172,7 +1181,28 @@ Rhizofs_fuse_main(struct fuse_args *args)
         check((fread(settings.server_public_key, 1, 40, fptr) == 40),
             "could not read %s", settings.server_public_key_file);
         fclose(fptr);
-        printf("key = '%s'\n", settings.server_public_key);
+    }
+
+    if (settings.client_public_key_file != NULL) {
+        FILE *fptr = NULL;
+        char client_secret_key_file[PATH_MAX];
+
+        fptr = fopen(settings.client_public_key_file, "rt");
+        check(fptr, "could not open %s", settings.client_public_key_file);
+        settings.client_public_key = (char *)calloc(1, 41);
+        check((fread(settings.client_public_key, 1, 40, fptr) == 40),
+            "could not read %s", settings.client_public_key_file);
+        fclose(fptr);
+
+        snprintf(client_secret_key_file, sizeof(client_secret_key_file),
+                 "%s.secret", settings.client_public_key_file);
+
+        fptr = fopen(client_secret_key_file, "rt");
+        check(fptr, "could not open %s", client_secret_key_file);
+        settings.client_secret_key = (char *)calloc(1, 41);
+        check((fread(settings.client_secret_key, 1, 40, fptr) == 40),
+            "could not read %s", client_secret_key_file);
+        fclose(fptr);
     }
 
     if (settings.check_socket_connection) {

--- a/src/fs/socketpool.c
+++ b/src/fs/socketpool.c
@@ -97,12 +97,16 @@ void *create_socket(void *ctx, int type, const char *server_public_key)
 #endif
 #endif
 
-    zmq_curve_keypair(public_key, secret_key);
-
     if (server_public_key != NULL) {
-        zmq_setsockopt(sock, ZMQ_CURVE_SERVERKEY, server_public_key, 40);
-        zmq_setsockopt(sock, ZMQ_CURVE_PUBLICKEY, public_key, 40);
-        zmq_setsockopt(sock, ZMQ_CURVE_SECRETKEY, secret_key, 40);
+        check((zmq_curve_keypair(public_key, secret_key) == 0),
+            "could not create client key pair");
+
+        check(zmq_setsockopt(sock, ZMQ_CURVE_SERVERKEY, server_public_key, 40) == 0,
+            "could not set server public key");
+        check(zmq_setsockopt(sock, ZMQ_CURVE_PUBLICKEY, public_key, 40) == 0,
+            "could not set client public key");
+        check(zmq_setsockopt(sock, ZMQ_CURVE_SECRETKEY, secret_key, 40) == 0,
+            "could not set client secret key");
     }
     return sock;
 error:

--- a/src/fs/socketpool.c
+++ b/src/fs/socketpool.c
@@ -80,6 +80,8 @@ void *
 SocketPool_get_socket(SocketPool * sp)
 {
     void * sock = NULL;
+    char public_key[41];
+    char secret_key[41];
 
     check(sp != NULL, "passed socketpool is NULL");
 
@@ -100,6 +102,14 @@ SocketPool_get_socket(SocketPool * sp)
         zmq_setsockopt(sock, ZMQ_LINGER, &linger, sizeof(linger));
 #endif
 #endif
+
+        zmq_curve_keypair(public_key, secret_key);
+
+        if (sp->server_public_key != NULL) {
+            zmq_setsockopt(sock, ZMQ_CURVE_SERVERKEY, sp->server_public_key, 40);
+            zmq_setsockopt(sock, ZMQ_CURVE_PUBLICKEY, public_key, 40);
+            zmq_setsockopt(sock, ZMQ_CURVE_SECRETKEY, secret_key, 40);
+        }
 
         check((zmq_connect(sock, sp->socket_name) == 0), "could not connect to socket");
         check((pthread_setspecific(sp->key, sock) == 0), "could not set socket in thread");

--- a/src/fs/socketpool.c
+++ b/src/fs/socketpool.c
@@ -77,11 +77,12 @@ error:
 }
 
 
-void *create_socket(void *ctx, int type, const char *server_public_key)
+void *create_socket(void *ctx, int type,
+                    const char *server_public_key,
+                    const char *client_public_key,
+                    const char *client_secret_key)
 {
     void * sock = NULL;
-    char public_key[41];
-    char secret_key[41];
 
     sock = zmq_socket(ctx, type);
     check((sock != NULL), "Could not create 0mq socket");
@@ -97,16 +98,30 @@ void *create_socket(void *ctx, int type, const char *server_public_key)
 #endif
 #endif
 
+    /* if server_public_key is set, encryption is enabled , otherwise it's unencrypted */
+    /* if encryption is enabled: if client_public_key and client_secret_key are set,
+       use them. Otherwise, we generate client keys on the fly. */
     if (server_public_key != NULL) {
-        check((zmq_curve_keypair(public_key, secret_key) == 0),
-            "could not create client key pair");
-
         check(zmq_setsockopt(sock, ZMQ_CURVE_SERVERKEY, server_public_key, 40) == 0,
             "could not set server public key");
-        check(zmq_setsockopt(sock, ZMQ_CURVE_PUBLICKEY, public_key, 40) == 0,
-            "could not set client public key");
-        check(zmq_setsockopt(sock, ZMQ_CURVE_SECRETKEY, secret_key, 40) == 0,
-            "could not set client secret key");
+
+        if (client_public_key == NULL || client_secret_key == NULL) {
+            char public_key[41];
+            char secret_key[41];
+
+            check((zmq_curve_keypair(public_key, secret_key) == 0),
+                "could not create client key pair");
+
+            check(zmq_setsockopt(sock, ZMQ_CURVE_PUBLICKEY, public_key, 40) == 0,
+                "could not set client public key");
+            check(zmq_setsockopt(sock, ZMQ_CURVE_SECRETKEY, secret_key, 40) == 0,
+                "could not set client secret key");
+        } else {
+            check(zmq_setsockopt(sock, ZMQ_CURVE_PUBLICKEY, client_public_key, 40) == 0,
+                "could not set client public key");
+            check(zmq_setsockopt(sock, ZMQ_CURVE_SECRETKEY, client_secret_key, 40) == 0,
+                "could not set client secret key");
+        }
     }
     return sock;
 error:
@@ -127,7 +142,9 @@ SocketPool_get_socket(SocketPool * sp)
     if (sock == NULL) {
 
         /* create a new socket */
-        sock = create_socket(sp->context, sp->socket_type, sp->server_public_key);
+        sock = create_socket(sp->context, sp->socket_type,
+                             sp->server_public_key,
+                             sp->client_public_key, sp->client_secret_key);
         check((sock != NULL), "Could not create 0mq socket");
 
         check((zmq_connect(sock, sp->socket_name) == 0), "could not connect to socket");

--- a/src/fs/socketpool.h
+++ b/src/fs/socketpool.h
@@ -32,12 +32,12 @@ typedef struct SocketPool {
 bool SocketPool_init(SocketPool * sp, void * context, const char * socket_name,
     int socket_type);
 
-inline
+static inline
 void SocketPool_set_server_public_key(SocketPool * sp, const char *key) {
     sp->server_public_key = key;
 }
 
-inline
+static inline
 void SocketPool_set_client_keypair(SocketPool * sp, const char *public_key, const char *secret_key) {
     sp->client_public_key = public_key;
     sp->client_secret_key = secret_key;

--- a/src/fs/socketpool.h
+++ b/src/fs/socketpool.h
@@ -14,6 +14,7 @@ typedef struct SocketPool {
     void * context;  /* 0mq context */
     char * socket_name;
     int socket_type;
+    const char *server_public_key;
 } SocketPool;
 
 
@@ -24,11 +25,16 @@ typedef struct SocketPool {
 bool SocketPool_init(SocketPool * sp, void * context, const char * socket_name,
     int socket_type);
 
+inline
+void SocketPool_set_server_public_key(SocketPool * sp, const char *key) {
+    sp->server_public_key = key;
+}
+
 /**
  * returns the 0mq socket for the current thread
  * or NULL on failure
  *
- * The socket will allready be connected to the
+ * The socket will already be connected to the
  * endpoint.
  */
 void * SocketPool_get_socket(SocketPool * sp);

--- a/src/fs/socketpool.h
+++ b/src/fs/socketpool.h
@@ -9,6 +9,8 @@
 #include <zmq.h>
 
 
+void *create_socket(void *ctx, int type, const char *server_public_key);
+
 typedef struct SocketPool {
     pthread_key_t   key;
     void * context;  /* 0mq context */

--- a/src/fs/socketpool.h
+++ b/src/fs/socketpool.h
@@ -9,13 +9,18 @@
 #include <zmq.h>
 
 
-void *create_socket(void *ctx, int type, const char *server_public_key);
+void *create_socket(void *ctx, int type,
+                    const char *server_public_key,
+                    const char *client_public_key,
+                    const char *client_secret_key);
 
 typedef struct SocketPool {
     pthread_key_t   key;
     void * context;  /* 0mq context */
     char * socket_name;
     int socket_type;
+    const char *client_public_key;
+    const char *client_secret_key;
     const char *server_public_key;
 } SocketPool;
 
@@ -30,6 +35,12 @@ bool SocketPool_init(SocketPool * sp, void * context, const char * socket_name,
 inline
 void SocketPool_set_server_public_key(SocketPool * sp, const char *key) {
     sp->server_public_key = key;
+}
+
+inline
+void SocketPool_set_client_keypair(SocketPool * sp, const char *public_key, const char *secret_key) {
+    sp->client_public_key = public_key;
+    sp->client_secret_key = secret_key;
 }
 
 /**

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -5,6 +5,7 @@
 #include <signal.h>
 #include <getopt.h>
 #include <pthread.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include <zmq.h>
@@ -19,36 +20,42 @@
 #define WORKER_SOCKET "inproc://workers"
 
 struct option opts_long[] = {
-    {"numworkers", 1, 0, 'n'},
-    {"help", 0, 0, 'h'},
-    {"version", 0, 0, 'v'},
-    {"verbose", 0, 0, 'V'},
-    {"logfile", 1, 0, 'l'},
-    {"pidfile", 1, 0, 'p'},
+    {"encrypt",    0, 0, 'e'},
     {"foreground", 0, 0, 'f'},
+    {"help",       0, 0, 'h'},
+    {"logfile",    1, 0, 'l'},
+    {"numworkers", 1, 0, 'n'},
+    {"pidfile",    1, 0, 'p'},
+    {"pubkeyfile", 1, 0, 'P'},
+    {"version",    0, 0, 'v'},
+    {"verbose",    0, 0, 'V'},
     {0, 0, 0, 0}
 };
 
-static const char *opts_short = "hvn:Vl:fp:";
+static const char *opts_short = "ehvn:Vl:fp:P:";
 
 static const char *opts_desc =
-    "  -h --help\n"
-    "  -v --version\n"
-    "  -V --verbose\n"
+    "  -e --encrypt\n"
     "  -f --foreground          foreground operation - do not daemonize.\n"
-    "  -n --numworkers=NUMBER   Number of worker threads to start [default=5]\n"
+    "  -h --help\n"
     "  -l --logfile=FILE        Logfile to use. Additionally it will always\n"
     "                           be logged to the syslog.\n"
+    "  -n --numworkers=NUMBER   Number of worker threads to start [default=5]\n"
     "  -p --pidfile=FILE        PID-file to write the PID of the daemonized server\n"
     "                           process to.\n"
-    "                           Has no effect if the server runs in the foreground.\n";
+    "                           Has no effect if the server runs in the foreground.\n"
+    "  -P --pubkeyfile          File to store the public key (needs --encrypt).\n"
+    "                           If not set, the public key will be written to stdout.\n"
+    "  -V --verbose\n"
+    "  -v --version\n";
 
 typedef struct ServerSettings {
     char * directory;
     char * socketname;
     int n_worker_threads;
-    bool verbose;
+    bool encrypt;
     bool foreground; // foreground operation - do not daemonize
+    bool verbose;
 } ServerSettings;
 static ServerSettings settings;
 
@@ -135,9 +142,11 @@ startup(const char *secret_key)
     in_socket = zmq_socket (context, ZMQ_XREP);
     check((in_socket != NULL), "Could not create zmq socket");
 
-    const int curve_server_enable = 1;
-    zmq_setsockopt(in_socket, ZMQ_CURVE_SERVER, &curve_server_enable, sizeof(curve_server_enable));
-    zmq_setsockopt(in_socket, ZMQ_CURVE_SECRETKEY, secret_key, 40);
+    if (secret_key != NULL) {
+        const int curve_server_enable = 1;
+        zmq_setsockopt(in_socket, ZMQ_CURVE_SERVER, &curve_server_enable, sizeof(curve_server_enable));
+        zmq_setsockopt(in_socket, ZMQ_CURVE_SECRETKEY, secret_key, 40);
+    }
 
     check((zmq_bind(in_socket, settings.socketname) == 0),
             "could not bind to socket %s", settings.socketname);
@@ -275,7 +284,7 @@ daemonize()
 
     // the PID file if desired
     if (pidfile) {
-        fprintf(pidfile, "%d", (int)sid);
+        fprintf(pidfile, "%d\n", (int)sid);
         fclose(pidfile);
         pidfile = NULL;
     }
@@ -294,6 +303,7 @@ main(int argc, char *argv[])
     const char * progname = argv[0];
     char public_key[41];
     char secret_key[41];
+    char *pubkey_file = NULL;
 
     // logging configuration
     dbg_disable_logfile();
@@ -331,8 +341,8 @@ main(int argc, char *argv[])
             case 'p':
                 pidfile = fopen(optarg, "w");
                 if (!pidfile) {
-                    fprintf(stderr, "Could not open pidfile %s for writting: %s\n",
-                        optarg, strerror(errno));
+                    fprintf(stderr, "Could not open pidfile %s for writting: %s (%d)\n",
+                        optarg, strerror(errno), errno);
                     shutdown(0);
                 }
                 break;
@@ -353,8 +363,16 @@ main(int argc, char *argv[])
                 settings.verbose = true;
                 break;
 
+            case 'e':
+                settings.encrypt = true;
+                break;
+
             case 'f':
                 settings.foreground = true;
+                break;
+
+            case 'P':
+                pubkey_file = strdup(optarg);
                 break;
 
             default:
@@ -374,15 +392,34 @@ main(int argc, char *argv[])
                 settings.directory, settings.socketname);
     }
 
-    {
-        zmq_curve_keypair(public_key, secret_key);
-        printf("public key: %s\n", public_key);
+    if (settings.encrypt) {
+        if (zmq_curve_keypair(public_key, secret_key) == 0) {
+            if (pubkey_file) {
+                 /* no rw for group and others */
+                mode_t old_mode = umask(0066);
+                FILE *fptr = fopen(pubkey_file, "wt");
+                if (fptr != NULL) {
+                    fprintf(fptr, "%s", public_key);
+                    fclose(fptr);
+                } else {
+                    fprintf(stderr, "Could not open public key file %s for writing: %s (%d)\n",
+                        pubkey_file, strerror(errno), errno);
+                        exit(1);
+                }
+                umask(old_mode);
+            } else {
+                printf("public key: %s\n", public_key);
+            }
+        } else {
+            fprintf(stderr, "Could not create key pair: %s (%d)\n",
+                strerror(errno), errno);
+            exit(1);
+        }
     }
 
     if (!settings.foreground) {
         daemonize();
-    }
-    else {
+    } else {
         // output log messages to stderr when no
         // other logfile is specified and the process
         // runs in foreground
@@ -391,7 +428,8 @@ main(int argc, char *argv[])
         }
     }
 
-    startup(secret_key);
+    startup(settings.encrypt ? secret_key : NULL);
+
+    if (pubkey_file)
+        free(pubkey_file);
 }
-
-

--- a/src/tools/rhizo-keygen.c
+++ b/src/tools/rhizo-keygen.c
@@ -1,0 +1,57 @@
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <zmq.h>
+
+
+int main (int argc, char *argv[])
+{
+    char public_key[41];
+    char secret_key[41];
+    FILE *fptr;
+    char *fname_pub;
+    char fname_secret[PATH_MAX];
+
+    if (argc != 2) {
+        fprintf(stderr, "usage: %s <public key file name>\n", argv[0]);
+        fprintf(stderr, "Generates a zmq curve key pair. The public key will be stored\n"
+                        "in the file given. The secret key will be stored in the file\n"
+                        "with the same name but with '.secret' appended.\n");
+        exit(1);
+    }
+
+    if (zmq_curve_keypair(public_key, secret_key)) {
+        if (zmq_errno() == ENOTSUP)
+            printf("To use %s, please install libsodium and then "
+                  "rebuild libzmq.", argv[0]);
+        exit (2);
+    }
+
+    umask(0066);
+
+    fname_pub = argv[1];
+    fptr = fopen(fname_pub, "wt");
+    if (fptr) {
+        fprintf(fptr, "%s", public_key);
+        fclose(fptr);
+    } else {
+        fprintf(stderr, "failed to open file %s for writing %s (%d):\n",
+                fname_pub, strerror(errno), errno);
+        exit(3);
+    }
+
+    snprintf(fname_secret, sizeof(fname_secret), "%s.secret", fname_pub);
+    fptr = fopen(fname_secret, "wt");
+    if (fptr) {
+        fprintf(fptr, "%s", secret_key);
+        fclose(fptr);
+    } else {
+        fprintf(stderr, "failed to open file %s for writing %s (%d):\n",
+                fname_secret, strerror(errno), errno);
+        exit(4);
+    }
+
+    exit (0);
+}


### PR DESCRIPTION
Add encryption.

If `--encrypt` is used for the server, and the option `--keyfile` is not given, it will create a key pair. The public key will be written to stdout or to a file if `--pubkeyfile` is used. The file will have permissions to be only readable by the user.

If `--encrypt` is used for the server, and the option `--keyfile=<keyfile>` is given, the file will be read for the public key, and the file with the same name but `.secret` appended will be read for the secret key.


The client can use the server public key either with the `--pubkey` option, or read from a file with the `--pubkeyfile` option. 

If additionally the client is invoked with the `--keyfile` option, the file will be read for the public key, and the file with the same name but `.secret` appended will be read for the secret key. Otherwise the client will generate a temporary key pair.


This adds the utility `rhizo-keygen` to create a key pair. It will create two files, one with the public key, and another with the secret key. For example, `rhizo-keygen foo-key` will generate a file `foo-key` witrh the public key, and a file `foo-key.secret` for the secret key.

