### PR TITLE
create temporary client keypair, if unset, only once

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,14 +204,15 @@ Mountpoint
 
 general options
 ---------------
-   -h --help           print help
-   -k --pubkey=<key>   set the server public key
-   --pubkeyfile=<file> set to file that contains the public key
-   -V --version        print version
+   --clientpubkeyfile=<file> set client keypair file
+   -h --help                 print help
+   -k --pubkey=<key>         set the server public key
+   --pubkeyfile=<file>       set to file that contains the public key
+   -V --version              print version
 
 Logging
 =======
-   In the case of errors or warnings this program will log to the syslog.
+   In the case of errors or warnings this program will log to syslog.
 
 FUSE options:
     -d   -o debug          enable debug output (implies -f)

--- a/src/fs/rhizofs.c
+++ b/src/fs/rhizofs.c
@@ -1100,10 +1100,11 @@ Rhizofs_usage(const char * progname)
         "\n"
         "general options\n"
         "---------------\n"
-        "   -h --help           print help\n"
-        "   -k --pubkey-<key>   set the server public key\n"
-        "   --pubkeyfile=<file> set to file that contains the public key\n"
-        "   -V --version        print version\n"
+        "   --clientpubkeyfile=<file> set client keypair file\n"
+        "   -h --help                 print help\n"
+        "   -k --pubkey=<key>         set the server public key\n"
+        "   --pubkeyfile=<file>       set to file that contains the public key\n"
+        "   -V --version              print version\n"
         "\n"
         HELPTEXT_LOGGING
         "\n", progname

--- a/src/fs/rhizofs.c
+++ b/src/fs/rhizofs.c
@@ -1183,26 +1183,34 @@ Rhizofs_fuse_main(struct fuse_args *args)
         fclose(fptr);
     }
 
-    if (settings.client_public_key_file != NULL) {
-        FILE *fptr = NULL;
-        char client_secret_key_file[PATH_MAX];
+    if (settings.server_public_key != NULL) {
+        if (settings.client_public_key_file != NULL) {
+            FILE *fptr = NULL;
+            char client_secret_key_file[PATH_MAX];
 
-        fptr = fopen(settings.client_public_key_file, "rt");
-        check(fptr, "could not open %s", settings.client_public_key_file);
-        settings.client_public_key = (char *)calloc(1, 41);
-        check((fread(settings.client_public_key, 1, 40, fptr) == 40),
-            "could not read %s", settings.client_public_key_file);
-        fclose(fptr);
+            fptr = fopen(settings.client_public_key_file, "rt");
+            check(fptr, "could not open %s", settings.client_public_key_file);
+            settings.client_public_key = (char *)calloc(1, 41);
+            check((fread(settings.client_public_key, 1, 40, fptr) == 40),
+                "could not read %s", settings.client_public_key_file);
+            fclose(fptr);
 
-        snprintf(client_secret_key_file, sizeof(client_secret_key_file),
-                 "%s.secret", settings.client_public_key_file);
+            snprintf(client_secret_key_file, sizeof(client_secret_key_file),
+                     "%s.secret", settings.client_public_key_file);
 
-        fptr = fopen(client_secret_key_file, "rt");
-        check(fptr, "could not open %s", client_secret_key_file);
-        settings.client_secret_key = (char *)calloc(1, 41);
-        check((fread(settings.client_secret_key, 1, 40, fptr) == 40),
-            "could not read %s", client_secret_key_file);
-        fclose(fptr);
+            fptr = fopen(client_secret_key_file, "rt");
+            check(fptr, "could not open %s", client_secret_key_file);
+            settings.client_secret_key = (char *)calloc(1, 41);
+            check((fread(settings.client_secret_key, 1, 40, fptr) == 40),
+                "could not read %s", client_secret_key_file);
+            fclose(fptr);
+        } else {
+            settings.client_public_key = (char *)calloc(1, 41);
+            settings.client_secret_key = (char *)calloc(1, 41);
+            check((zmq_curve_keypair(settings.client_public_key,
+                                     settings.client_secret_key) == 0),
+                "could not create client key pair");
+        }
     }
 
     if (settings.check_socket_connection) {

--- a/src/fs/socketpool.c
+++ b/src/fs/socketpool.c
@@ -102,26 +102,15 @@ void *create_socket(void *ctx, int type,
     /* if encryption is enabled: if client_public_key and client_secret_key are set,
        use them. Otherwise, we generate client keys on the fly. */
     if (server_public_key != NULL) {
+        check(client_public_key != NULL, "client public key is not set");
+        check(client_secret_key != NULL, "client secret key is not set");
+
         check(zmq_setsockopt(sock, ZMQ_CURVE_SERVERKEY, server_public_key, 40) == 0,
             "could not set server public key");
-
-        if (client_public_key == NULL || client_secret_key == NULL) {
-            char public_key[41];
-            char secret_key[41];
-
-            check((zmq_curve_keypair(public_key, secret_key) == 0),
-                "could not create client key pair");
-
-            check(zmq_setsockopt(sock, ZMQ_CURVE_PUBLICKEY, public_key, 40) == 0,
-                "could not set client public key");
-            check(zmq_setsockopt(sock, ZMQ_CURVE_SECRETKEY, secret_key, 40) == 0,
-                "could not set client secret key");
-        } else {
-            check(zmq_setsockopt(sock, ZMQ_CURVE_PUBLICKEY, client_public_key, 40) == 0,
-                "could not set client public key");
-            check(zmq_setsockopt(sock, ZMQ_CURVE_SECRETKEY, client_secret_key, 40) == 0,
-                "could not set client secret key");
-        }
+        check(zmq_setsockopt(sock, ZMQ_CURVE_PUBLICKEY, client_public_key, 40) == 0,
+            "could not set client public key");
+        check(zmq_setsockopt(sock, ZMQ_CURVE_SECRETKEY, client_secret_key, 40) == 0,
+            "could not set client secret key");
     }
     return sock;
 error:

--- a/src/helptext.h
+++ b/src/helptext.h
@@ -27,7 +27,7 @@
 #define HELPTEXT_LOGGING \
 "Logging\n" \
 "=======\n" \
-"   In the case of errors or warnings this program will log to the syslog.\n"
+"   In the case of errors or warnings this program will log to syslog.\n"
 
 
 #endif


### PR DESCRIPTION
This fixes issue #6 .  It's not safe to call `zmq_curve_keypair()` more than once, at least on MacOS. See https://github.com/jedisct1/libsodium/discussions/1311 .

This change will create a keypair, unless set with the `clientpubkeyfile` option, once on start. Previously, it was created each time a socket was created, and this lead to crashes in `libsodium`.

Also minor fixes to the help text.