### PR TITLE
update debian package scripts

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+rhizofs (0.2.4-1) unstable; urgency=low
+
+  * enable encryption
+  * and other bug fixes
+
+ -- Oliver Kurth <okurth@gmail.com>  Sat, 07 Oct 2023 19:56:45 -0700
+
 rhizofs (0.2.2-1) unstable; urgency=low
 
   * build with ZeroMQ 3

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: rhizofs
 Section: net
 Priority: optional
-Maintainer: Nico Mandery <nico@nmandery.net>
+Maintainer: Oliver Kurth <okurth@gmail.com>
 Build-Depends: debhelper (>= 6.0.7~), libzmq3-dev, pkg-config,
         libprotobuf-c-dev, protobuf-c-compiler,
         libfuse-dev
@@ -9,19 +9,25 @@ Standards-Version: 3.9.1
 
 Package: rhizofs
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, rhizofs-common (= ${binary:Version})
 Description: a simple remote filesystem based on FUSE, ZeroMQ and protobuf-c.
     This package contains the client.
 
 Package: rhizofs-server
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, rhizofs-common (= ${binary:Version})
 Description: a simple remote filesystem based on FUSE, ZeroMQ and protobuf-c.
     This package contains the server.
+
+Package: rhizofs-common
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: a simple remote filesystem based on FUSE, ZeroMQ and protobuf-c.
+    This package contains common utilities.
 
 Package: rhizofs-dbg
 Section: debug
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Description: a simple remote filesystem based on FUSE, ZeroMQ and protobuf-c
+Description: a simple remote filesystem based on FUSE, ZeroMQ and protobuf-c.
         This package contains the debugging symbols.

--- a/debian/rhizofs-common.install
+++ b/debian/rhizofs-common.install
@@ -1,0 +1,1 @@
+usr/bin/rhizo-keygen

--- a/debian/rhizofs-server.install
+++ b/debian/rhizofs-server.install
@@ -1,0 +1,1 @@
+usr/bin/rhizosrv

--- a/debian/rhizofs.install
+++ b/debian/rhizofs.install
@@ -1,0 +1,1 @@
+usr/bin/rhizofs


### PR DESCRIPTION
Adding `*.install` files for sub packages (how was this working before?), and adding an extra package for the `rhizo-keygen` utility.