### PR TITLE
implement zap CURVE auth using client's public key

### DIFF
--- a/pytest/common.py
+++ b/pytest/common.py
@@ -45,15 +45,19 @@ def start_server(endpoint, directory, args=[]):
     ret = run([RHIZOSRV, endpoint, directory] + args + ["-p", pidfile_path])
     print(ret.stderr)
     print(ret.stdout)
+    print(ret.retval)
+
     assert ret.retval == 0
 
     return ret
 
 
-def start_client(endpoint, directory, args=[]):
+def start_client(endpoint, directory, args=[], ignore_fail=False):
     pwd = os.getcwd()
     ret = run([RHIZOFS] + args + [endpoint, directory])
-    assert ret.retval == 0
+
+    if not ignore_fail:
+        assert ret.retval == 0
 
     return ret
 


### PR DESCRIPTION
Adds authentication using the client's public key. Enabled by adding the `-a` option with a file containing the allowed public keys, one on each line. If the key is not found access is denied.

Implemented following mainly the example from http://www.evilpaul.org/wp/2017/05/02/authentication-encryption-zeromq/ .