### PR TITLE
use int64 for file sizes and offsets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,13 +49,13 @@ ${BINDIR}:
 	@[ -d ${BINDIR} ] || mkdir ${BINDIR}
 
 ${BINDIR}/rhizosrv: ${SERVER_OBJECTS} ${BINDIR}
-	$(CC) -o ${BINDIR}/rhizosrv ${SERVER_OBJECTS} $(CFLAGS) $(LIBS)
+	$(CC) -o ${BINDIR}/rhizosrv ${SERVER_OBJECTS} $(LIBS)
 
 ${BINDIR}/rhizofs: ${FS_OBJECTS} ${BINDIR}
-	$(CC) -o ${BINDIR}/rhizofs ${FS_OBJECTS} $(CFLAGS) $(LIBS) $(FUSE_LIBS)
+	$(CC) -o ${BINDIR}/rhizofs ${FS_OBJECTS} $(LIBS) $(FUSE_LIBS)
 
 ${BINDIR}/rhizo-keygen: ${TOOLS_OBJECTS} ${BINDIR}
-	$(CC) -o ${BINDIR}/rhizo-keygen ${TOOLS_OBJECTS} $(CFLAGS) $(shell pkg-config libzmq --libs)
+	$(CC) -o ${BINDIR}/rhizo-keygen ${TOOLS_OBJECTS} $(shell pkg-config libzmq --libs)
 
 ${SERVER_SOURCES} ${FS_SOURCES}: ${PROTO_H_COMPILED}
 

--- a/pytest/test_bigfiles.py
+++ b/pytest/test_bigfiles.py
@@ -72,3 +72,16 @@ def test_gigafile():
 
     assert checksum_true == checksum_client
 
+
+def test_giga5file():
+    basename = "giga5.blob"
+
+    filepath_srv = os.path.join(SRV_DIR, basename)
+    write_random_binary(filepath_srv, 5 * 1024**3)
+    checksum_true = calc_checksum(filepath_srv)
+
+    filepath_client = os.path.join(CLIENT_DIR, basename)
+    checksum_client = calc_checksum(filepath_client)
+
+    assert checksum_true == checksum_client
+

--- a/src/fs/rhizofs.c
+++ b/src/fs/rhizofs.c
@@ -628,9 +628,9 @@ Rhizofs_read(const char *path, char *buf, size_t size,
 
     request.path = (char *)path;
     request.has_size = 1;
-    request.size = (int)size;
+    request.size = (int64_t)size;
     request.has_offset = 1;
-    request.offset = (int)offset;
+    request.offset = (int64_t)offset;
     request.requesttype = RHIZOFS__REQUEST_TYPE__READ;
 
     OP_COMMUNICATE(request, response, returned_err)
@@ -660,9 +660,9 @@ Rhizofs_write(const char * path, const char * buf, size_t size, off_t offset,
 
     request.path = (char *)path;
     request.has_size = 1;
-    request.size = (int)size;
+    request.size = (int64_t)size;
     request.has_offset = 1;
-    request.offset = (int)offset;
+    request.offset = (int64_t)offset;
     request.requesttype = RHIZOFS__REQUEST_TYPE__WRITE;
     check((Request_set_data(&request, (const uint8_t *) buf, (size_t)size) == true),
             "could not set request data");
@@ -688,7 +688,7 @@ Rhizofs_truncate(const char * path, off_t offset)
     OP_INIT(request, response, returned_err);
 
     request.path = (char *)path;
-    request.offset = (int)offset;
+    request.offset = (int64_t)offset;
     request.has_offset = 1;
     request.requesttype = RHIZOFS__REQUEST_TYPE__TRUNCATE;
 

--- a/src/proto/rhizofs.proto
+++ b/src/proto/rhizofs.proto
@@ -167,8 +167,8 @@ message Request {
     optional DataBlock datablock = 7;
 
     // number of bytes to read/write
-    optional int32 size = 8;
-    optional int32 offset = 9;
+    optional int64 size = 8;
+    optional int64 offset = 9;
 
     // filetype - for open operation
     optional FileType filetype = 10;
@@ -194,7 +194,7 @@ message Response {
     optional DataBlock datablock = 6;
 
     // number of bytes to read/write
-    optional int32 size = 8;
+    optional int64 size = 8;
 
     // the target a link/symlink points to
     // this string has to be null terminated

--- a/src/server/servedir.c
+++ b/src/server/servedir.c
@@ -795,7 +795,7 @@ ServeDir_op_write(const ServeDir * sd, Rhizofs__Request * request, Rhizofs__Resp
         ssize_t bytes_written = pwrite(fd, data, (size_t)request->size, (off_t)request->offset);
         if (bytes_written == -1) {
             Response_set_errno(response, errno);
-            debug("Could not write %d bytes to %s", (int)request->size, path);
+            debug("Could not write %ld bytes to %s", (int64_t)request->size, path);
             errno = 0;
         }
 


### PR DESCRIPTION
Use 64 bit integers for file sizes and offsets to support files > 2 GB.

This protocol change should keep compatibility, see https://protobuf.dev/programming-guides/dos-donts/ , but to support  files > 2 GB both client and server need this change.