### PR TITLE
fix calculating the checksum of files

### DIFF
--- a/pytest/test_bigfiles.py
+++ b/pytest/test_bigfiles.py
@@ -57,7 +57,9 @@ def write_random_binary(filename, size):
 
 def calc_checksum(filename):
     with open(filename, "rb") as f:
-        return hashlib.md5(f.read()).hexdigest()
+        m = hashlib.sha256()
+        m.update(f.read())
+        return m.hexdigest()
 
 
 def test_gigafile():


### PR DESCRIPTION
The test for 5GB files would occasionally fail because `hashlib` wasn't used the right way.