### PR TITLE
fix build issue in src/mapping.c 'member reference base type 'long' i…

### DIFF
--- a/src/mapping.c
+++ b/src/mapping.c
@@ -472,9 +472,9 @@ Attrs_copy_to_stat(const Rhizofs__Attrs * attrs, struct stat * stat_result)
     stat_result->st_ctime  = attrs->timestamps->creation_sec;
 
 #ifndef __USE_XOPEN2K8
-	stat_result->st_atimensec.tv_nsec = attrs->timestamps->access_usec * 1000;
-	stat_result->st_mtimensec.tv_nsec = attrs->timestamps->modify_usec * 1000;
-	stat_result->st_ctimensec.tv_nsec = attrs->timestamps->creation_usec * 1000;
+	stat_result->st_atimensec = attrs->timestamps->access_usec * 1000;
+	stat_result->st_mtimensec = attrs->timestamps->modify_usec * 1000;
+	stat_result->st_ctimensec = attrs->timestamps->creation_usec * 1000;
 #else
 	stat_result->st_atim.tv_nsec = attrs->timestamps->access_usec * 1000;
 	stat_result->st_mtim.tv_nsec = attrs->timestamps->modify_usec * 1000;


### PR DESCRIPTION
Missed a build error on MacOS:
```
cc -Wall -Wextra -Wno-format-extra-args -Wformat-nonliteral -Wformat-security -Wformat=2 -Isrc -D_XOPEN_SOURCE=600 -D_DEFAULT_SOURCE -I. -D_FILE_OFFSET_BITS=64 -I/usr/local/include/fuse -I. -I/opt/homebrew/Cellar/protobuf-c/1.5.0_3/include -I. -I/opt/homebrew/Cellar/zeromq/4.3.5_1/include -I/opt/homebrew/Cellar/libsodium/1.0.19/include -DNDEBUG -O2 -g -std=c99 -c src/mapping.c -o src/mapping.o
src/mapping.c:475:27: error: member reference base type 'long' is not a structure or union
        stat_result->st_atimensec.tv_nsec = attrs->timestamps->access_usec * 1000;
        ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
src/mapping.c:476:27: error: member reference base type 'long' is not a structure or union
        stat_result->st_mtimensec.tv_nsec = attrs->timestamps->modify_usec * 1000;
        ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
src/mapping.c:477:27: error: member reference base type 'long' is not a structure or union
        stat_result->st_ctimensec.tv_nsec = attrs->timestamps->creation_usec * 1000;
        ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
3 errors generated.
```